### PR TITLE
Fix classification.send() for marking tools

### DIFF
--- a/api.coffee
+++ b/api.coffee
@@ -21,6 +21,9 @@ class Api extends EventEmitter
     if typeof data is 'function'
       [fail, done, data] = [done, data, null]
 
+    if typeof data is 'object'
+      data = JSON.parse JSON.stringify data
+
     request = $.ajax {type, url, data, dataType}
     request.done done
     request.fail fail


### PR DESCRIPTION
JSON encode, then decode, classifications otherwise $.ajax will break when it tries to convert marking annotations to URL-encoded form data.
Closes #5